### PR TITLE
Jest test finder can get misled by irrelevant "describe" blocks

### DIFF
--- a/test/test-npm-jest.el-test.el
+++ b/test/test-npm-jest.el-test.el
@@ -349,7 +349,7 @@ describe('AppComponent', () => {
     const app = fixture.componentInstance;
     expect(app).toBeTruthy();
   });
-"))
+})"))
     (with-temp-js-buffer
       (insert buffer-contents)
       (goto-char 190)
@@ -372,8 +372,44 @@ describe('AppComponent', () => {
     const app = fixture.componentInstance;
     expect(app).toBeTruthy();
   });
-"))
+})"))
     (with-temp-js-buffer
       (insert buffer-contents)
       (goto-char 288)
       (should (equal (test-cockpit-npm-jest--find-current-test) "AppComponent should create the test app")))))
+
+
+(ert-deftest test-npm-empty-describe-block-before-it ()
+  (let ((buffer-contents "
+describe('outer', () => {
+  describe('middle', () => {
+  });
+
+  it('foo', async () => {
+    expect(2).toBe(2); // HERE
+  });
+});
+"))
+    (with-temp-js-buffer
+      (insert buffer-contents)
+      (goto-char 100)
+      (should (equal (test-cockpit-npm-jest--find-current-test) "outer foo")))))
+
+(ert-deftest test-npm-non-empty-describe-block-before-it ()
+  (let ((buffer-contents "
+describe('outer', () => {
+  describe('middle', () => {
+    it('bar', async () => {
+      expect(2).toBe(2); // HERE
+    });
+  });
+
+  it('foo', async () => {
+    expect(2).toBe(2); // HERE
+  });
+});
+"))
+    (with-temp-js-buffer
+      (insert buffer-contents)
+      (goto-char 150)
+      (should (equal (test-cockpit-npm-jest--find-current-test) "outer foo")))))


### PR DESCRIPTION
Thanks @ktfleming for reporting this. Sorry, I accidentally transformed the issue you reported into a pull request. But anyway. This PR seems to fix it.


Hey, I'm really finding this package useful, thanks for creating it!

I've found that `(test-cockpit-npm-jest--find-current-test)` doesn't handle the following case:

```typescript
describe("outer", () => {
  describe("middle", () => {
  });

  it("foo", async () => {
    expect(2).toBe(2); // HERE
  });
});
```

If I put point on the line marked `// HERE` and evaluate `(test-cockpit-npm-jest--find-current-test)`, the output is `"middle foo"`, rather than the expected `"outer foo"`. It seems that it's looking for the closest preceding `"describe"` via `search-backward-regexp`, rather than looking for the `"describe"` that contains the test at point.

I do see you have an open issue https://github.com/johannes-mueller/test-cockpit.el/issues/7 for looking into tree-sitter which I imagine could help with this by allowing you to look at only the parent node of the current node.